### PR TITLE
gitdown, markdown-it, markdown-it-deflist 를 이용한 Doc. Builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.npmrc
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .npmrc
 node_modules
+npm-debug.log

--- a/bin/docbuild
+++ b/bin/docbuild
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+'use strict';
+
+const docbuild = require('../index.js');
+
+var ArgumentParser = require('argparse').ArgumentParser;
+var parser = new ArgumentParser({
+  version: '0.0.1',
+  addHelp: true,
+  description: 'Argparse example'
+});
+parser.addArgument(
+  [ '-s', '--source' ],
+  {
+    help: 'source directory'
+  }
+);
+parser.addArgument(
+  [ '-d', '--destination' ],
+  {
+    help: 'destination directory'
+  }
+);
+var args = parser.parseArgs();
+console.dir(args);
+
+docbuild(args.source, args.destination)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,11 @@
+const gulp = require('gulp');
+const path = require('path');
+const docbuild = require('./index.js');
+
+gulp.task('docbuild', () => {
+  docbuild(path.resolve(__dirname, 'src'));
+});
+
+gulp.task('watch', () => {
+    gulp.watch(['./src/*'], ['docbuild']);
+});

--- a/index.js
+++ b/index.js
@@ -1,0 +1,38 @@
+const Gitdown = require('gitdown');
+const MarkdownIt = require('markdown-it');
+const md = new MarkdownIt();
+md.use(require('markdown-it-deflist'));
+const fs = require('fs');
+const path = require('path');
+
+module.exports = (srcDir, destDir) => {
+  fs.readdirSync(srcDir).forEach(file => {
+    const fileName = path.resolve(srcDir, file);
+    if (fs.lstatSync(fileName).isDirectory()) return;
+    const destName = path.resolve(destDir, file).replace(/\.md$/, '.html');
+    const gitdown = Gitdown.readFile(fileName);
+    gitdown.setConfig({
+      headingNesting: {
+        enabled: false
+      }
+    })
+    gitdown.get().then(gitdownString => {
+      const lines = gitdownString.split("\n");
+      if (lines[0] === '---') {
+        for (var i = 1; i < lines.length; i++) {
+          if (lines[i] === '---') break;
+        }
+      }
+      let frontMatter = [];
+      for (let j = 0; j < i+1; j++) {
+        frontMatter[j] = lines[j];
+        delete lines[j];
+      }
+
+      const markdown = lines.join("\n");
+      const htmlString = md.render(markdown);
+      const outputString = frontMatter.join("\n") + "\n" + htmlString;
+      return fs.writeFileSync(destName, outputString);                          
+    }); 
+  });
+};

--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@ const Gitdown = require('gitdown');
 const MarkdownIt = require('markdown-it');
 const md = new MarkdownIt({
   highlight: function (str, lang) {
-    if (lang && hljs.getLanguage(lang)) {
-      try {
-        return hljs.highlight(lang, str).value;
-      } catch (__) {}
+    let outputString = '';
+    if (lang === 'syntax') {
+      outputString = '<pre-syntax>{{< highlight json >}}' + str + '{{< /highlight >}}</pre-syntax>';
+      console.log(outputString);
+    } else {
+      outputString = '<pre-code>{{< highlight ' + lang + '>}}' + str + '{{< /highlight >}}</pre-code>';
     }
-    return '';
+    return outputString;
   }
 });
 md.use(require('markdown-it-deflist'));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,16 @@
+const hljs = require('highlight.js');
 const Gitdown = require('gitdown');
 const MarkdownIt = require('markdown-it');
-const md = new MarkdownIt();
+const md = new MarkdownIt({
+  highlight: function (str, lang) {
+    if (lang && hljs.getLanguage(lang)) {
+      try {
+        return hljs.highlight(lang, str).value;
+      } catch (__) {}
+    }
+    return '';
+  }
+});
 md.use(require('markdown-it-deflist'));
 const fs = require('fs');
 const path = require('path');

--- a/index.js
+++ b/index.js
@@ -1,57 +1,90 @@
-const hljs = require('highlight.js');
-const markedpp = require('markedpp');
-const MarkdownIt = require('markdown-it');
-const md = new MarkdownIt({
-  html: true,
+const md = require('markdown-it')({
+  // hugo의 code highlight를 사용하기 위해 {{< highlight ... >}} 처리한다.
+  // hugo에서 자동으로 <pre><code> 태그가 붙기 때문에 여기(markdown-it)에서는
+  // 빼야하는데 여기에도 <pre><code> 태그가 자동으로 붙는다.
+  // 그래서 <pre-[syntax|code]> 와 같이 처리해주고 pre-syntax는 왼쪽 본문에
+  // 들어가는 Syntax로 구분 해준다.
   highlight: function (str, lang) {
-    let outputString = '';
+    let outputString = ''
     if (lang === 'syntax') {
-      outputString = '<pre-syntax>{{< highlight json >}}' + str + '{{< /highlight >}}</pre-syntax>';
+      outputString = '<pre-syntax>{{< highlight json >}}' + str + '{{< /highlight >}}</pre-syntax>'
     } else {
-      outputString = '<pre-code>{{< highlight ' + lang + '>}}' + str + '{{< /highlight >}}</pre-code>';
+      outputString = '<pre-code>{{< highlight ' + lang + '>}}' + str + '{{< /highlight >}}</pre-code>'
     }
-    return outputString;
+    return outputString
   }
-});
-md.use(require('markdown-it-deflist'));
+})
+
+// nested definition list 를 위해 사용
+md.use(require('markdown-it-deflist'))
+
+// heading 태그에 id를 넣기 위해 사용
+// 스페이스가 올경우 '-' 넣어주어서 내부 링크에도 문제 없도록 한다.
 md.use(require('markdown-it-named-headers'), {
   slugify: function(inputString) {
-    return inputString.replace(/ /g, '-');
+    return inputString.replace(/ /g, '-')
   }
-});
-const fs = require('fs');
-const path = require('path');
+})
+
+const fs = require('fs')
+const path = require('path')
 
 module.exports = (srcDir, destDir) => {
-  realSrc = fs.realpathSync(srcDir);
-  realDest = fs.realpathSync(destDir);
-  dirs = fs.readdirSync(realSrc);
-  process.chdir(realSrc);
-  dirs.forEach(file => {
-    const fileName = path.resolve(realSrc, file);
-    if (fs.lstatSync(fileName).isDirectory()) return;
-    const destName = path.resolve(realDest, file).replace(/\.md$/, '.html');
-    const fileContent = fs.readFileSync(fileName).toString();
-    const lines = fileContent.split("\n");
+  // 절대경로 가져오기
+  realSrc = fs.realpathSync(srcDir)
+  realDest = fs.realpathSync(destDir)
+
+  // 디렉토리 안의 목록
+  dirList = fs.readdirSync(realSrc)
+
+  // working directory를 바꿔줘야 한다.
+  process.chdir(realSrc)
+
+  dirList.forEach(file => {
+    const fileName = path.resolve(realSrc, file)
+
+    // 디렉토리는 그냥 패스
+    if (fs.lstatSync(fileName).isDirectory()) return
+
+    const destName = path.resolve(realDest, file).replace(/\.md$/, '.html')
+    const fileContent = fs.readFileSync(fileName).toString()
+    let lines = fileContent.split("\n")
+
+    // front matter 는 markdown 파싱할 부분이 아니므로 따로 추출한다.
     if (lines[0] === '---') {
       for (var i = 1; i < lines.length; i++) {
-        if (lines[i] === '---') break;
+        if (lines[i] === '---') break
       }
     }
-    let frontMatter = [];
+    let frontMatter = []
     for (let j = 0; j < i+1; j++) {
-      frontMatter[j] = lines[j];
-      delete lines[j];
+      frontMatter[j] = lines[j]
+      delete lines[j]
     }
-    const markdown = lines.join("\n");
-    markedpp(
-      markdown,
-      {},
-      (err, markedppString) => {
-        const htmlString = md.render(markedppString);
-        const outputString = frontMatter.join("\n") + "\n" + htmlString;
-        return fs.writeFileSync(destName, outputString);
+
+    // %include가 발견되면 파일을 읽어 해당 라인에 replace 한다.
+    for (let j = 0; j < lines.length; j++) {
+      if (!lines[j]) continue
+      if (lines[j].startsWith('%include')) {
+        const parameters = lines[j].split(' ')
+        lines[j] = include(parseInt(parameters[1]), parameters[2])
       }
-    ); 
-  });
-};
+    }
+
+    // Markdown 렌더링해서 frontMatter와 함께 파일에 쓴다.
+    const htmlString = md.render(lines.join("\n"))
+    const outputString = frontMatter.join("\n") + "\n" + htmlString
+    return fs.writeFileSync(destName, outputString)
+  })
+}
+
+// fileName의 파일의 읽어서 라인별로 spaces 만큼 공백을 왼쪽으로 채우고 
+// string을 리턴한다.
+function include(spaces, fileName) {
+  const fileContent = fs.readFileSync(fileName).toString()
+  const lines = fileContent.split("\n")
+  for (let i = 0; i < lines.length; i++) {
+    lines[i] = ' '.repeat(spaces) + lines[i]
+  }
+  return lines.join("\n")
+}

--- a/index.js
+++ b/index.js
@@ -14,6 +14,11 @@ const md = new MarkdownIt({
   }
 });
 md.use(require('markdown-it-deflist'));
+md.use(require('markdown-it-named-headers'), {
+  slugify: function(inputString) {
+    return inputString;
+  }
+});
 const fs = require('fs');
 const path = require('path');
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 const hljs = require('highlight.js');
-const Gitdown = require('gitdown');
+const markedpp = require('markedpp');
 const MarkdownIt = require('markdown-it');
 const md = new MarkdownIt({
+  html: true,
   highlight: function (str, lang) {
     let outputString = '';
     if (lang === 'syntax') {
       outputString = '<pre-syntax>{{< highlight json >}}' + str + '{{< /highlight >}}</pre-syntax>';
-      console.log(outputString);
     } else {
       outputString = '<pre-code>{{< highlight ' + lang + '>}}' + str + '{{< /highlight >}}</pre-code>';
     }
@@ -16,40 +16,42 @@ const md = new MarkdownIt({
 md.use(require('markdown-it-deflist'));
 md.use(require('markdown-it-named-headers'), {
   slugify: function(inputString) {
-    return inputString;
+    return inputString.replace(/ /g, '-');
   }
 });
 const fs = require('fs');
 const path = require('path');
 
 module.exports = (srcDir, destDir) => {
-  fs.readdirSync(srcDir).forEach(file => {
-    const fileName = path.resolve(srcDir, file);
+  realSrc = fs.realpathSync(srcDir);
+  realDest = fs.realpathSync(destDir);
+  dirs = fs.readdirSync(realSrc);
+  process.chdir(realSrc);
+  dirs.forEach(file => {
+    const fileName = path.resolve(realSrc, file);
     if (fs.lstatSync(fileName).isDirectory()) return;
-    const destName = path.resolve(destDir, file).replace(/\.md$/, '.html');
-    const gitdown = Gitdown.readFile(fileName);
-    gitdown.setConfig({
-      headingNesting: {
-        enabled: false
+    const destName = path.resolve(realDest, file).replace(/\.md$/, '.html');
+    const fileContent = fs.readFileSync(fileName).toString();
+    const lines = fileContent.split("\n");
+    if (lines[0] === '---') {
+      for (var i = 1; i < lines.length; i++) {
+        if (lines[i] === '---') break;
       }
-    })
-    gitdown.get().then(gitdownString => {
-      const lines = gitdownString.split("\n");
-      if (lines[0] === '---') {
-        for (var i = 1; i < lines.length; i++) {
-          if (lines[i] === '---') break;
-        }
+    }
+    let frontMatter = [];
+    for (let j = 0; j < i+1; j++) {
+      frontMatter[j] = lines[j];
+      delete lines[j];
+    }
+    const markdown = lines.join("\n");
+    markedpp(
+      markdown,
+      {},
+      (err, markedppString) => {
+        const htmlString = md.render(markedppString);
+        const outputString = frontMatter.join("\n") + "\n" + htmlString;
+        return fs.writeFileSync(destName, outputString);
       }
-      let frontMatter = [];
-      for (let j = 0; j < i+1; j++) {
-        frontMatter[j] = lines[j];
-        delete lines[j];
-      }
-
-      const markdown = lines.join("\n");
-      const htmlString = md.render(markdown);
-      const outputString = frontMatter.join("\n") + "\n" + htmlString;
-      return fs.writeFileSync(destName, outputString);                          
-    }); 
+    ); 
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docbuild",
-  "version": "1.0.8",
+  "version": "1.0.11",
   "description": "COOLSMS documentation builder",
   "main": "index.js",
   "scripts": {
@@ -15,6 +15,7 @@
     "gitdown": "^2.5.0",
     "highlight.js": "^9.12.0",
     "markdown-it": "^8.4.0",
-    "markdown-it-deflist": "^2.0.3"
+    "markdown-it-deflist": "^2.0.3",
+    "markdown-it-named-headers": "0.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docbuild",
-  "version": "1.0.2",
+  "version": "1.0.8",
   "description": "COOLSMS documentation builder",
   "main": "index.js",
   "scripts": {
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "gitdown": "^2.5.0",
+    "highlight.js": "^9.12.0",
     "markdown-it": "^8.4.0",
     "markdown-it-deflist": "^2.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docbuild",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "COOLSMS documentation builder",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docbuild",
-  "version": "1.0.11",
+  "version": "1.0.14",
   "description": "COOLSMS documentation builder",
   "main": "index.js",
   "scripts": {
@@ -12,10 +12,10 @@
     "gulp": "^3.9.1"
   },
   "dependencies": {
-    "gitdown": "^2.5.0",
     "highlight.js": "^9.12.0",
     "markdown-it": "^8.4.0",
     "markdown-it-deflist": "^2.0.3",
-    "markdown-it-named-headers": "0.0.4"
+    "markdown-it-named-headers": "0.0.4",
+    "markedpp": "^0.3.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "docbuild",
+  "version": "1.0.2",
+  "description": "COOLSMS documentation builder",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "wiley",
+  "license": "ISC",
+  "devDependencies": {
+    "gulp": "^3.9.1"
+  },
+  "dependencies": {
+    "gitdown": "^2.5.0",
+    "markdown-it": "^8.4.0",
+    "markdown-it-deflist": "^2.0.3"
+  }
+}

--- a/src/example.md
+++ b/src/example.md
@@ -1,0 +1,2 @@
+# Heading 1
+## Heading 2

--- a/src/example.md
+++ b/src/example.md
@@ -1,2 +1,7 @@
-# Heading 1
+---
+title: front-matter
+---
+
+# 헤딩 1
 ## Heading 2
+!include (./fragment.md)

--- a/src/fragment.md
+++ b/src/fragment.md
@@ -1,0 +1,2 @@
+Title
+: Description


### PR DESCRIPTION
COOLSMS에 필요한 Nested definition list(markdown-it-deflist)가 지원됨.

gulp 사용 예

```javascript
const path = require('path');
const gulp = require('gulp');
const docbuild = require('docbuild');

gulp.task('docbuild', () => {
  docbuild(
    path.resolve(__dirname, 'src'),
    path.resolve(__dirname, 'content')
  )
});

gulp.task('watch', () => {
    gulp.watch(['./src/*'], ['docbuild']);
});
```